### PR TITLE
zip check only occur when output is zip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 cowabunga.exe
 cowabunga64.exe
+assets.pie
+assets.zip


### PR DESCRIPTION
### Description
This pull request addresses #12 by:
- Adding a check to validate ZIP files only if the output file extension is `.zip`.
- Improving error handling for unsupported output formats.
- Updating success/error messages to reflect file validation logic.

### Testing
- Verified the fix with `.zip`, `.txt`, and `.pie` extensions to ensure correct behavior.
- Confirmed that invalid ZIP files are flagged, and non-ZIP files are processed correctly.

### Related Issue
Closes #12 (https://github.com/Masquerade64/Cowabunga/issues/12#issuecomment-2566111699)
