### PR TITLE
Add Linux and macOS support

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,11 @@
+#[cfg(target_os = "windows")]
 extern crate winres;
 
 fn main() {
-    let mut res = winres::WindowsResource::new();
-    res.set_icon("icon.ico");
-    res.compile().unwrap();
+    #[cfg(target_os = "windows")]
+    {
+        let mut res = winres::WindowsResource::new();
+        res.set_icon("icon.ico");
+        res.compile().unwrap();
+    }
 }


### PR DESCRIPTION
I noticed building the utility on Linux results to a failure due to the incompatible dependency `winres`. Making it a Windows-only requirement allows Cowabunga to be compiled and used on both Linux and macOS.