### PR TITLE
Add Rayman 30th Anniversary key

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Decryption tool for assets.pie for Digital Eclipse games:
 - Yu-Gi-Oh! EARLY DAYS COLLECTION
 - Mortal Kombat Legacy Collection
 - Golden Tee Arcade Classics
+- Rayman: 30th Anniversary Edition 
 
 This tool was made in its entirety by SowwyItsAnAlt.
 
@@ -43,6 +44,7 @@ mighty-morphin
 yu-gi-oh
 mortal-kombat-lc
 golden-tee
+rayman30th
 ```
 The key for Tetris Forever is the same as `jeff-minter`.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ enum Key {
 	YuGiOh          = 0x55D7F83B,
 	MortalKombatLC  = 0x41D3AAA6,
 	GoldenTee       = 0x2E8D9A77,
+	Rayman30th      = 0x64DA7B23,
 }
 
 fn main() {


### PR DESCRIPTION
Fixes #25 

```
cargo run -- --help

Options:
  -k, --key <KEY>            Game key for decryption/encryption [default: cowabunga] [possible values:
    cowabunga, atari, atari-dlc1, atari-dlc2, atari-dlc3, making-karateka, garbage-pail-kids, jeff-minter,
    blizzard-arcade, mighty-morphin, yu-gi-oh, mortal-kombat-lc, golden-tee, rayman30th]
```